### PR TITLE
.obj instead of objectMode

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ module.exports = function(templ) {
     callback(null, template(chunk));
   };
 
-  return through({objectMode: true}, transform);
+  return through.obj(transform);
 };


### PR DESCRIPTION
`though2` exposes a `.obj(transform, [flush])` method that converts the stream to objectMode.
The difference between this and using `though({objectMode:true}, ...)` is that it also sets `hwm` to 16 instead of 16k (a bug that is fixed in node 0.12 as well). Without the `hwm` fix backpressure will (almost) never be used and the stream could end up using a lot of ram.
