### PR TITLE
Allow for use of handlebars functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,3 +25,5 @@ module.exports = function(templ, opts) {
 
   return through.obj(transform, flush);
 };
+
+module.exports.handlebars = handlebars


### PR DESCRIPTION
Hey there.

I was using this module but was saddened by the fact that I couldn't use handlebars' other functions, like `registerHelper`. I went ahead and changed some things around. Now, module.exports is just handlebars, with the addition of the function `createTemplateStream`, which is what was used before to compile templates. For example

Before:

``` js
handlebars("Hello {{planet}}")
```

After:

``` js
handlebars.createTemplateStream("Hello {{planet}}")
```

Have a nice day! 
